### PR TITLE
[feature]都道府県選択コンポーネントの実装

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.0.3",
+    "@tanstack/react-query": "^5.66.0",
     "clsx": "^2.1.1",
     "lucide-react": "^0.475.0",
     "react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "lucide-react": "^0.475.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-error-boundary": "^5.0.0",
     "tailwind-merge": "^3.0.1",
     "tailwindcss": "^4.0.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.0.3
         version: 4.0.4(vite@6.0.9(@types/node@22.13.1)(jiti@2.4.2)(lightningcss@1.29.1))
+      '@tanstack/react-query':
+        specifier: ^5.66.0
+        version: 5.66.0(react@18.3.1)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -1031,6 +1034,14 @@ packages:
     resolution: {integrity: sha512-zrWGbluPeXeoetUQoDFmt1dQIeiOBThfznla7zPIqST69rMmiDD4SZwJrHVoL5CvXz06AYQXz/M/jELSakL7Rg==}
     peerDependencies:
       vite: ^5.2.0 || ^6
+
+  '@tanstack/query-core@5.66.0':
+    resolution: {integrity: sha512-J+JeBtthiKxrpzUu7rfIPDzhscXF2p5zE/hVdrqkACBP8Yu0M96mwJ5m/8cPPYQE9aRNvXztXHlNwIh4FEeMZw==}
+
+  '@tanstack/react-query@5.66.0':
+    resolution: {integrity: sha512-z3sYixFQJe8hndFnXgWu7C79ctL+pI0KAelYyW+khaNJ1m22lWrhJU2QrsTcRKMuVPtoZvfBYrTStIdKo+x0Xw==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@testing-library/dom@10.4.0':
     resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
@@ -3665,6 +3676,13 @@ snapshots:
       lightningcss: 1.29.1
       tailwindcss: 4.0.4
       vite: 6.0.9(@types/node@22.13.1)(jiti@2.4.2)(lightningcss@1.29.1)
+
+  '@tanstack/query-core@5.66.0': {}
+
+  '@tanstack/react-query@5.66.0(react@18.3.1)':
+    dependencies:
+      '@tanstack/query-core': 5.66.0
+      react: 18.3.1
 
   '@testing-library/dom@10.4.0':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      react-error-boundary:
+        specifier: ^5.0.0
+        version: 5.0.0(react@18.3.1)
       tailwind-merge:
         specifier: ^3.0.1
         version: 3.0.1
@@ -2334,6 +2337,11 @@ packages:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
       react: ^18.3.1
+
+  react-error-boundary@5.0.0:
+    resolution: {integrity: sha512-tnjAxG+IkpLephNcePNA7v6F/QpWLH8He65+DmedchDwg162JZqx4NmbXj0mlAYVVEd81OW7aFhmbsScYfiAFQ==}
+    peerDependencies:
+      react: '>=16.13.1'
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
@@ -5004,6 +5012,11 @@ snapshots:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
+
+  react-error-boundary@5.0.0(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.26.7
+      react: 18.3.1
 
   react-is@17.0.2: {}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,22 +1,14 @@
-import { useState } from "react";
+import { PopulationByPrefecture } from "./features/population-by-prefecture/components/PopulationByPrefecture";
 
 function App() {
-  const [count, setCount] = useState(0);
-
   return (
     <>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button type="button" onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
+      <div className="min-h-screen bg-indigo-50 p-4 sm:p-6 lg:p-8 text-gray-700">
+        <div className="max-w-7xl mx-auto space-y-6">
+          <h1 className="text-3xl font-bold">都道府県人口比較</h1>
+          <PopulationByPrefecture />
+        </div>
       </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
     </>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,10 +4,10 @@ function App() {
   return (
     <>
       <div className="min-h-screen bg-indigo-50 p-4 sm:p-6 lg:p-8 text-gray-700">
-        <div className="max-w-7xl mx-auto space-y-6">
+        <main className="max-w-7xl mx-auto space-y-6">
           <h1 className="text-3xl font-bold">都道府県人口比較</h1>
           <PopulationByPrefecture />
-        </div>
+        </main>
       </div>
     </>
   );

--- a/src/api/prefectures.ts
+++ b/src/api/prefectures.ts
@@ -1,6 +1,6 @@
 import { configs } from "@/configs";
 
-type Prefecture = {
+export type Prefecture = {
   /** 都道府県コード */
   prefCode: number;
   /** 都道府県名 */

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -13,8 +13,8 @@ export const Button = forwardRef<HTMLButtonElement, Props>(function ButtonBase(
 ) {
   const colorClass = clsx(
     variant === "primary" && "bg-blue-600 hover:bg-blue-700",
-    ["secondary", "default"].includes(variant) &&
-      "bg-gray-600 hover:bg-gray-700",
+    variant === "secondary" && "bg-red-400 hover:bg-red-500",
+    variant === "default" && "bg-gray-600 hover:bg-gray-700",
   );
   const buttonClass = cn(
     "flex items-center gap-2 cursor-pointer px-4 py-2 text-white rounded-lg transition-colors disabled:opacity-50",

--- a/src/components/Checkbox/index.tsx
+++ b/src/components/Checkbox/index.tsx
@@ -6,7 +6,7 @@ type Props = ComponentPropsWithRef<"input">;
 export const Checkbox = forwardRef<HTMLInputElement, Props>(
   function CheckboxBase({ className, ...props }, ref) {
     const classes = cn(
-      "w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded-sm focus:ring-blue-500 focus:ring-2",
+      "w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded-sm cursor-pointer focus:ring-blue-500 focus:ring-2",
       className,
     );
     return <input type="checkbox" {...props} ref={ref} className={classes} />;

--- a/src/components/LoadingSpinner/index.tsx
+++ b/src/components/LoadingSpinner/index.tsx
@@ -2,7 +2,10 @@ import { Loader2 } from "lucide-react";
 import type { FC } from "react";
 
 export const LoadingSpinner: FC = () => (
-  <div className="flex justify-center items-center p-2">
+  <div
+    className="flex justify-center items-center p-2"
+    data-testid="loading-spinner"
+  >
     <Loader2 className="animate-spin" />
   </div>
 );

--- a/src/features/population-by-prefecture/components/PopulationByPrefecture/index.test.tsx
+++ b/src/features/population-by-prefecture/components/PopulationByPrefecture/index.test.tsx
@@ -1,0 +1,52 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import { PopulationByPrefecture } from ".";
+import { useSelectedPrefectures } from "../../hooks/use-selected-prefectures";
+
+vi.mock("../../hooks/use-selected-prefectures", () => ({
+  useSelectedPrefectures: vi.fn(),
+}));
+
+describe("PopulationByPrefecture", () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false, // リトライを無効化
+      },
+    },
+  });
+
+  beforeEach(() => {
+    vi.mocked(useSelectedPrefectures).mockReturnValue({
+      selectedPrefectures: [],
+      selectPrefecture: vi.fn(),
+      deselectPrefectures: vi.fn(),
+      clearAll: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const renderComponent = () => {
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <PopulationByPrefecture />
+      </QueryClientProvider>,
+    );
+  };
+
+  it("初期表示ではloadingコンポーネントがそれぞれ表示されており、データ取得できるとloadingコンポーネントは非表示となる", async () => {
+    renderComponent();
+
+    expect(screen.getAllByTestId("loading-spinner")).toHaveLength(1);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("loading-spinner")).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /すべてクリア/i }),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/features/population-by-prefecture/components/PopulationByPrefecture/index.tsx
+++ b/src/features/population-by-prefecture/components/PopulationByPrefecture/index.tsx
@@ -1,0 +1,39 @@
+import { LoadingSpinner } from "@/components/LoadingSpinner";
+import { Suspense } from "react";
+import { ErrorBoundary } from "react-error-boundary";
+import { useSelectedPrefectures } from "../../hooks/use-selected-prefectures";
+import { PrefectureSelector } from "../PrefectureSelector";
+
+export const PopulationByPrefecture = () => {
+  const {
+    selectedPrefectures,
+    selectPrefecture,
+    deselectPrefectures,
+    clearAll,
+  } = useSelectedPrefectures();
+
+  return (
+    <>
+      <Suspense fallback={<LoadingSpinner />}>
+        <ErrorBoundary
+          fallbackRender={({ error }) => <div>{error.message}</div>}
+        >
+          <PrefectureSelector
+            selectedPrefectures={selectedPrefectures}
+            onSelectPrefecture={selectPrefecture}
+            onDeselectPrefecture={deselectPrefectures}
+            clearAll={clearAll}
+          />
+        </ErrorBoundary>
+      </Suspense>
+
+      {/* <Suspense fallback={<LoadingSpinner />}>
+        <ErrorBoundary
+          fallbackRender={({ error }) => <div>{error.message}</div>}
+        >
+          <p>TODO: グラフ</p>
+        </ErrorBoundary>
+      </Suspense> */}
+    </>
+  );
+};

--- a/src/features/population-by-prefecture/components/PrefectureItem/index.test.tsx
+++ b/src/features/population-by-prefecture/components/PrefectureItem/index.test.tsx
@@ -1,0 +1,51 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { PrefectureItem } from ".";
+
+describe("PrefectureItem", () => {
+  const mockOnChange = vi.fn();
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("nameに与えた文字列でtextが設定される", () => {
+    render(
+      <PrefectureItem name="北海道" checked={false} onChange={mockOnChange} />,
+    );
+
+    expect(screen.getByText("北海道")).toBeInTheDocument();
+  });
+
+  it("checkedに与えた真偽値でcheck状態が設定される", () => {
+    const { rerender } = render(
+      <PrefectureItem name="北海道" checked={false} onChange={mockOnChange} />,
+    );
+
+    const checkbox = screen.getByRole("checkbox") as HTMLInputElement;
+    expect(checkbox.checked).toBe(false);
+
+    rerender(
+      <PrefectureItem name="北海道" checked={true} onChange={mockOnChange} />,
+    );
+    expect(checkbox.checked).toBe(true);
+  });
+
+  it.each([true, false])(
+    "clickするとonChangeイベントがコールされて、check状態が反転する 初期値: %s",
+    (checked) => {
+      render(
+        <PrefectureItem
+          name="北海道"
+          checked={checked}
+          onChange={mockOnChange}
+        />,
+      );
+
+      const checkbox = screen.getByRole("checkbox");
+      fireEvent.click(checkbox);
+
+      expect(mockOnChange).toHaveBeenCalledTimes(1);
+      expect(mockOnChange).toHaveBeenCalledWith(!checked);
+    },
+  );
+});

--- a/src/features/population-by-prefecture/components/PrefectureItem/index.tsx
+++ b/src/features/population-by-prefecture/components/PrefectureItem/index.tsx
@@ -13,14 +13,14 @@ export const PrefectureItem = memo(
     return (
       <label
         htmlFor={checkboxId}
-        className="flex items-center gap-2 cursor-pointer p-2 rounded-sm hover:bg-gray-300"
+        className="flex items-center gap-2 cursor-pointer px-1 py-2 rounded-sm hover:bg-gray-300"
       >
         <Checkbox
           id={checkboxId}
           checked={checked}
           onChange={(e) => onChange(e.target.checked)}
         />
-        <span className="text-xs sm:text-md">{name}</span>
+        <span className="text-sm sm:text-lg">{name}</span>
       </label>
     );
   },

--- a/src/features/population-by-prefecture/components/PrefectureItem/index.tsx
+++ b/src/features/population-by-prefecture/components/PrefectureItem/index.tsx
@@ -1,0 +1,33 @@
+import { Checkbox } from "@/components/Checkbox";
+import { memo, useId } from "react";
+
+interface PrefectureItemProps {
+  name: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}
+
+export const PrefectureItem = memo(
+  function PrefectureItem({ name, checked, onChange }: PrefectureItemProps) {
+    const checkboxId = useId();
+    return (
+      <label
+        htmlFor={checkboxId}
+        className="flex items-center gap-2 cursor-pointer p-2 rounded-sm hover:bg-gray-300"
+      >
+        <Checkbox
+          id={checkboxId}
+          checked={checked}
+          onChange={(e) => onChange(e.target.checked)}
+        />
+        <span className="text-xs sm:text-md">{name}</span>
+      </label>
+    );
+  },
+  (prevProps, nextProps) => {
+    return (
+      prevProps.checked === nextProps.checked &&
+      prevProps.name === nextProps.name
+    );
+  },
+);

--- a/src/features/population-by-prefecture/components/PrefectureSelector/index.test.tsx
+++ b/src/features/population-by-prefecture/components/PrefectureSelector/index.test.tsx
@@ -1,0 +1,113 @@
+import {
+  type Prefecture,
+  type PrefecturesResponse,
+  fetchPrefectures,
+} from "@/api/prefectures";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { PrefectureSelector } from ".";
+
+vi.mock("@/api/prefectures", () => ({
+  fetchPrefectures: vi.fn(),
+}));
+
+const mockPrefectures: PrefecturesResponse = {
+  message: "success",
+  result: [
+    { prefCode: 1, prefName: "北海道" },
+    { prefCode: 2, prefName: "青森" },
+  ],
+};
+
+describe("PrefectureSelector", () => {
+  const mockOnSelectPrefecture = vi.fn();
+  const mockOnDeselectPrefecture = vi.fn();
+  const mockClearAll = vi.fn();
+
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false, // リトライを無効化
+      },
+    },
+  });
+
+  beforeEach(() => {
+    vi.mocked(fetchPrefectures).mockResolvedValue(mockPrefectures);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const renderComponent = (selectedPrefectures: Prefecture[] = []) => {
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <PrefectureSelector
+          selectedPrefectures={selectedPrefectures}
+          onSelectPrefecture={mockOnSelectPrefecture}
+          onDeselectPrefecture={mockOnDeselectPrefecture}
+          clearAll={mockClearAll}
+        />
+      </QueryClientProvider>,
+    );
+  };
+
+  it("APIからデータを取得後、結果に従ってレンダリングされる", async () => {
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText("北海道")).toBeInTheDocument();
+      expect(screen.getByText("青森")).toBeInTheDocument();
+    });
+  });
+
+  it("選択状態が正しくレンダリングされる", async () => {
+    renderComponent([{ prefCode: 1, prefName: "北海道" }]);
+
+    await waitFor(() => {
+      const checkboxes = screen.getAllByRole("checkbox") as HTMLInputElement[];
+      expect(checkboxes[0].checked).toBe(true);
+      expect(checkboxes[1].checked).toBe(false);
+    });
+  });
+
+  it("未チェックの都道府県の選択すると、onSelectPrefectureの関数がコールされる", async () => {
+    renderComponent();
+
+    await waitFor(() => {
+      const checkbox = screen.getByLabelText("北海道") as HTMLInputElement;
+      fireEvent.click(checkbox);
+    });
+
+    expect(mockOnSelectPrefecture).toHaveBeenCalledTimes(1);
+    expect(mockOnSelectPrefecture).toHaveBeenCalledWith({
+      prefCode: 1,
+      prefName: "北海道",
+    });
+  });
+
+  it("チェック済みの都道府県の選択すると、onDeselectPrefectureの関数がコールされる", async () => {
+    renderComponent([{ prefCode: 1, prefName: "北海道" }]);
+
+    await waitFor(() => {
+      const checkbox = screen.getByLabelText("北海道") as HTMLInputElement;
+      fireEvent.click(checkbox);
+    });
+
+    expect(mockOnDeselectPrefecture).toHaveBeenCalledTimes(1);
+    expect(mockOnDeselectPrefecture).toHaveBeenCalledWith({
+      prefCode: 1,
+      prefName: "北海道",
+    });
+  });
+
+  it("「すべてクリア」のボタンをクリックすると、clearAllの関数がコールされる", async () => {
+    renderComponent([{ prefCode: 1, prefName: "北海道" }]);
+
+    const clearButton = screen.getByRole("button", { name: /すべてクリア/i });
+    fireEvent.click(clearButton);
+
+    expect(mockClearAll).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/population-by-prefecture/components/PrefectureSelector/index.tsx
+++ b/src/features/population-by-prefecture/components/PrefectureSelector/index.tsx
@@ -24,9 +24,9 @@ export const PrefectureSelector: FC<PrefectureSelectorProps> = ({
   });
 
   return (
-    <div className="bg-gray-100 text-gray-700 rounded-lg shadow-md p-4">
+    <div className="bg-white text-gray-700 rounded-lg shadow-md p-4">
       <div className="mt-2">
-        <Button onClick={clearAll}>
+        <Button variant="secondary" onClick={clearAll}>
           <XCircle />
           すべてクリア
         </Button>

--- a/src/features/population-by-prefecture/components/PrefectureSelector/index.tsx
+++ b/src/features/population-by-prefecture/components/PrefectureSelector/index.tsx
@@ -24,7 +24,8 @@ export const PrefectureSelector: FC<PrefectureSelectorProps> = ({
   });
 
   return (
-    <div className="bg-white text-gray-700 rounded-lg shadow-md p-4">
+    <section className="bg-white text-gray-700 rounded-lg shadow-md p-4">
+      <h2 className="text-lg font-bold">都道府県選択</h2>
       <div className="mt-2">
         <Button variant="secondary" onClick={clearAll}>
           <XCircle />
@@ -51,6 +52,6 @@ export const PrefectureSelector: FC<PrefectureSelectorProps> = ({
           );
         })}
       </div>
-    </div>
+    </section>
   );
 };

--- a/src/features/population-by-prefecture/components/PrefectureSelector/index.tsx
+++ b/src/features/population-by-prefecture/components/PrefectureSelector/index.tsx
@@ -1,0 +1,56 @@
+import { type Prefecture, fetchPrefectures } from "@/api/prefectures";
+import { Button } from "@/components/Button";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { XCircle } from "lucide-react";
+import type { FC } from "react";
+import { PrefectureItem } from "../PrefectureItem";
+
+type PrefectureSelectorProps = {
+  selectedPrefectures: Prefecture[];
+  onSelectPrefecture: (prefecture: Prefecture) => void;
+  onDeselectPrefecture: (prefecture: Prefecture) => void;
+  clearAll: () => void;
+};
+
+export const PrefectureSelector: FC<PrefectureSelectorProps> = ({
+  selectedPrefectures,
+  onSelectPrefecture,
+  onDeselectPrefecture,
+  clearAll,
+}) => {
+  const { data: prefectures } = useSuspenseQuery({
+    queryKey: ["prefectures"],
+    queryFn: fetchPrefectures,
+  });
+
+  return (
+    <div className="bg-gray-100 text-gray-700 rounded-lg shadow-md p-4">
+      <div className="mt-2">
+        <Button onClick={clearAll}>
+          <XCircle />
+          すべてクリア
+        </Button>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2 p-2 sm:grid-cols-4 md:grid-cols-6">
+        {prefectures.result.map((prefecture) => {
+          return (
+            <PrefectureItem
+              key={prefecture.prefCode}
+              name={prefecture.prefName}
+              checked={selectedPrefectures.some(
+                (selectedPrefecture) =>
+                  selectedPrefecture.prefCode === prefecture.prefCode,
+              )}
+              onChange={(checked) => {
+                checked
+                  ? onSelectPrefecture(prefecture)
+                  : onDeselectPrefecture(prefecture);
+              }}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/src/features/population-by-prefecture/hooks/use-selected-prefectures.test.ts
+++ b/src/features/population-by-prefecture/hooks/use-selected-prefectures.test.ts
@@ -1,0 +1,58 @@
+import type { Prefecture } from "@/api/prefectures";
+import { act, renderHook } from "@testing-library/react";
+import { useSelectedPrefectures } from "./use-selected-prefectures";
+
+describe("useSelectedPrefectures", () => {
+  const mockPrefecture1: Prefecture = { prefCode: 1, prefName: "Hokkaido" };
+  const mockPrefecture2: Prefecture = { prefCode: 2, prefName: "Aomori" };
+
+  it("stateの初期状態は空", () => {
+    const { result } = renderHook(() => useSelectedPrefectures());
+    expect(result.current.selectedPrefectures).toEqual([]);
+  });
+
+  it("selectPrefecture によってアイテムが追加される", () => {
+    const { result } = renderHook(() => useSelectedPrefectures());
+
+    act(() => {
+      result.current.selectPrefecture(mockPrefecture1);
+    });
+
+    expect(result.current.selectedPrefectures).toEqual([mockPrefecture1]);
+  });
+
+  it("同一アイテムを追加した場合、1つのアイテムのみ存在する", () => {
+    const { result } = renderHook(() => useSelectedPrefectures());
+
+    act(() => {
+      result.current.selectPrefecture(mockPrefecture1);
+      result.current.selectPrefecture(mockPrefecture1);
+    });
+
+    expect(result.current.selectedPrefectures).toEqual([mockPrefecture1]);
+  });
+
+  it("deselectPrefectures によってアイテムが削除される", () => {
+    const { result } = renderHook(() => useSelectedPrefectures());
+
+    act(() => {
+      result.current.selectPrefecture(mockPrefecture1);
+      result.current.selectPrefecture(mockPrefecture2);
+      result.current.deselectPrefectures(mockPrefecture1);
+    });
+
+    expect(result.current.selectedPrefectures).toEqual([mockPrefecture2]);
+  });
+
+  it("複数アイテムが追加されていてもclearAllを実行すると空になる", () => {
+    const { result } = renderHook(() => useSelectedPrefectures());
+
+    act(() => {
+      result.current.selectPrefecture(mockPrefecture1);
+      result.current.selectPrefecture(mockPrefecture2);
+      result.current.clearAll();
+    });
+
+    expect(result.current.selectedPrefectures).toEqual([]);
+  });
+});

--- a/src/features/population-by-prefecture/hooks/use-selected-prefectures.ts
+++ b/src/features/population-by-prefecture/hooks/use-selected-prefectures.ts
@@ -1,0 +1,36 @@
+import type { Prefecture } from "@/api/prefectures";
+import { useCallback, useState } from "react";
+
+export const useSelectedPrefectures = () => {
+  const [selectedPrefectures, setSelectedPrefectures] = useState<Prefecture[]>(
+    [],
+  );
+
+  const selectPrefecture = useCallback(
+    (prefecture: Prefecture) =>
+      setSelectedPrefectures((prev) => {
+        if (prev.some((pref) => pref.prefCode === prefecture.prefCode)) {
+          return prev;
+        }
+        return [...prev, prefecture];
+      }),
+    [],
+  );
+
+  const deselectPrefectures = useCallback(
+    (prefecture: Prefecture) =>
+      setSelectedPrefectures((prev) =>
+        prev.filter((pref) => pref.prefCode !== prefecture.prefCode),
+      ),
+    [],
+  );
+
+  const clearAll = useCallback(() => setSelectedPrefectures([]), []);
+
+  return {
+    selectedPrefectures,
+    selectPrefecture,
+    deselectPrefectures,
+    clearAll,
+  };
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,4 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
@@ -19,7 +20,9 @@ enableMocking().then(() => {
     document.body.appendChild(document.createElement("div"));
   createRoot(root).render(
     <StrictMode>
-      <App />
+      <QueryClientProvider client={new QueryClient()}>
+        <App />
+      </QueryClientProvider>
     </StrictMode>,
   );
 });


### PR DESCRIPTION
# 概要
- 都道府県コンポーネントの実装
- 実装に伴い、多少のスタイル調整も加えています

# 補足
- 機能単位でのcomponentやモジュールは `src/features/{機能名}/`のディレクトリに切っています
- 機能単位のcomponentはstorybookの定義はしていません。
- あくまでも今回は都道府県ごとの人口推移のグラフのみが目的のため、Routerは不要とした前提で実装しています。

# 参考資料
tanstack queryにおけるsuspenseの利用
https://tanstack.com/query/v4/docs/framework/react/guides/suspense

# 動作確認
## 表示
### PC幅 (width: 1280px)
![スクリーンショット 2025-02-09 19 29 33](https://github.com/user-attachments/assets/f75ee8d3-c9ae-4ba6-a78d-f834bc22de8d)

### SP幅 (375px)
![スクリーンショット 2025-02-09 19 29 47](https://github.com/user-attachments/assets/b5ffb436-287f-451e-86f2-045c853b0e39)

## 選択結果がstateに保持されている状態であることの確認
![スクリーンショット 2025-02-09 19 30 13](https://github.com/user-attachments/assets/d53c4790-5ad8-4e0d-aa1d-a88970771a69)

![スクリーンショット 2025-02-09 19 30 18](https://github.com/user-attachments/assets/17cdfbcf-036c-47a0-818f-33a4c3382e25)
