### PR TITLE
[fix]buildエラー解消_Tabのprops修正に伴うstoriesファイルの修正

### DIFF
--- a/src/components/Tab/index.stories.tsx
+++ b/src/components/Tab/index.stories.tsx
@@ -14,18 +14,18 @@ export const Default: StoryObj = {
       <Tab.Title>Tab Component</Tab.Title>
       <Tab.List
         tabItems={[
-          { id: 0, content: "Tab 1" },
-          { id: 1, content: "Tab 2" },
-          { id: 2, content: "Tab 3" },
-          { id: 3, content: "Tab 4" },
+          { id: "0", content: "Tab 1" },
+          { id: "1", content: "Tab 2" },
+          { id: "2", content: "Tab 3" },
+          { id: "3", content: "Tab 4" },
         ]}
       />
       <Tab.PanelList
         panelItems={[
-          { id: 0, content: "Content 1" },
-          { id: 1, content: "Content 2" },
-          { id: 2, content: "Content 3" },
-          { id: 3, content: "Content 4" },
+          { id: "0", content: "Content 1" },
+          { id: "1", content: "Content 2" },
+          { id: "2", content: "Content 3" },
+          { id: "3", content: "Content 4" },
         ]}
       />
     </Tab.Group>


### PR DESCRIPTION
# 概要
buildエラーが発生
https://github.com/mgr-kb/prefectures-population-app/actions/runs/13257052227

原因は下記PRの対応の中で、Tabコンポーネントのpropsの型定義が変わったことによる、storiesファイルの修正漏れです
https://github.com/mgr-kb/prefectures-population-app/pull/13

該当の問題を解消してbuildができたことを確認しています。
