### PR TITLE
[fix]エラー時のハンドリングを修正

### DIFF
--- a/src/features/population-by-prefecture/components/PopulationByPrefecture/index.tsx
+++ b/src/features/population-by-prefecture/components/PopulationByPrefecture/index.tsx
@@ -17,7 +17,11 @@ export const PopulationByPrefecture = () => {
     <>
       <Suspense fallback={<LoadingSpinner />}>
         <ErrorBoundary
-          fallbackRender={({ error }) => <div>{error.message}</div>}
+          fallbackRender={() => (
+            <p role="alert" className="text-red-700">
+              都道府県情報を取得できませんでした。再度お試しください。
+            </p>
+          )}
         >
           <PrefectureSelector
             selectedPrefectures={selectedPrefectures}
@@ -30,7 +34,11 @@ export const PopulationByPrefecture = () => {
 
       <Suspense fallback={<LoadingSpinner />}>
         <ErrorBoundary
-          fallbackRender={({ error }) => <div>{error.message}</div>}
+          fallbackRender={() => (
+            <p role="alert" className="text-red-700">
+              人口情報を取得できませんでした。再度お試しください。
+            </p>
+          )}
         >
           <PopulationChart selectedPrefectures={selectedPrefectures} />
         </ErrorBoundary>

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -7,9 +7,11 @@ const { baseUrl, prefectures, populationCompositionPerYear } = configs;
 
 export const restHandlers = [
   http.get(`${baseUrl}${prefectures.path}`, () => {
+    // return HttpResponse.error();
     return HttpResponse.json(prefecturesResponse);
   }),
   http.get(`${baseUrl}${populationCompositionPerYear.path}`, () => {
+    // return HttpResponse.error();
     return HttpResponse.json(populationCompositionPerYearResponse());
   }),
 ];


### PR DESCRIPTION
# 概要
エラー時のfallbackメッセージを見直し (システム内のエラー情報が出る形のままになっていたため)

## 都道府県一覧取得エラー
![スクリーンショット 2025-02-11 15 38 57](https://github.com/user-attachments/assets/1e27f9e1-e3b9-4120-a5fe-6bf3501cf0ae)

## 人口情報取得エラー
![スクリーンショット 2025-02-11 15 39 12](https://github.com/user-attachments/assets/7c1ed0cc-5823-4e43-a683-407fc1a1b115)
