### PR TITLE
[fix]UIの微修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>都道府県別の総人口推移グラフ</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ function App() {
     <>
       <div className="min-h-screen bg-indigo-50 p-4 sm:p-6 lg:p-8 text-gray-700">
         <main className="max-w-7xl mx-auto space-y-6">
-          <h1 className="text-3xl font-bold">都道府県人口比較</h1>
+          <h1 className="text-3xl font-bold">都道府県別の総人口推移グラフ</h1>
           <PopulationByPrefecture />
         </main>
       </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,9 @@ function App() {
     <>
       <div className="min-h-screen bg-indigo-50 p-4 sm:p-6 lg:p-8 text-gray-700">
         <main className="max-w-7xl mx-auto space-y-6">
-          <h1 className="text-3xl font-bold">都道府県別の総人口推移グラフ</h1>
+          <h1 className="text-xl sm:text-2xl font-bold">
+            都道府県別の総人口推移グラフ
+          </h1>
           <PopulationByPrefecture />
         </main>
       </div>

--- a/src/features/population-by-prefecture/components/PopulationByPrefecture/index.test.tsx
+++ b/src/features/population-by-prefecture/components/PopulationByPrefecture/index.test.tsx
@@ -45,7 +45,7 @@ describe("PopulationByPrefecture", () => {
     await waitFor(() => {
       expect(screen.queryByTestId("loading-spinner")).not.toBeInTheDocument();
       expect(
-        screen.getByRole("button", { name: /すべてクリア/i }),
+        screen.getByRole("button", { name: /選択をクリア/i }),
       ).toBeInTheDocument();
     });
   });

--- a/src/features/population-by-prefecture/components/PopulationChart/index.tsx
+++ b/src/features/population-by-prefecture/components/PopulationChart/index.tsx
@@ -95,7 +95,7 @@ const Chart: FC<ChartProps> = ({ data, prefectures }) => {
       className="bg-white rounded-lg shadow-md p-2 h-[600px] overflow-x-auto"
       data-testid="chart"
     >
-      <ResponsiveContainer height={580} width="100%" minWidth={375}>
+      <ResponsiveContainer height={580} width="100%" minWidth={800}>
         <LineChart
           data={data}
           margin={{ top: 20, right: 30, left: 20, bottom: 5 }}

--- a/src/features/population-by-prefecture/components/PrefectureItem/index.tsx
+++ b/src/features/population-by-prefecture/components/PrefectureItem/index.tsx
@@ -13,14 +13,14 @@ export const PrefectureItem = memo(
     return (
       <label
         htmlFor={checkboxId}
-        className="flex items-center gap-2 cursor-pointer px-1 py-2 rounded-sm hover:bg-gray-300"
+        className="flex items-center gap-1 cursor-pointer py-1 rounded-sm hover:bg-gray-300"
       >
         <Checkbox
           id={checkboxId}
           checked={checked}
           onChange={(e) => onChange(e.target.checked)}
         />
-        <span className="text-sm sm:text-lg">{name}</span>
+        <span className="text-sm sm:text-base">{name}</span>
       </label>
     );
   },

--- a/src/features/population-by-prefecture/components/PrefectureSelector/index.test.tsx
+++ b/src/features/population-by-prefecture/components/PrefectureSelector/index.test.tsx
@@ -102,10 +102,10 @@ describe("PrefectureSelector", () => {
     });
   });
 
-  it("「すべてクリア」のボタンをクリックすると、clearAllの関数がコールされる", async () => {
+  it("「選択をクリア」のボタンをクリックすると、clearAllの関数がコールされる", async () => {
     renderComponent([{ prefCode: 1, prefName: "北海道" }]);
 
-    const clearButton = screen.getByRole("button", { name: /すべてクリア/i });
+    const clearButton = screen.getByRole("button", { name: /選択をクリア/i });
     fireEvent.click(clearButton);
 
     expect(mockClearAll).toHaveBeenCalledTimes(1);

--- a/src/features/population-by-prefecture/components/PrefectureSelector/index.tsx
+++ b/src/features/population-by-prefecture/components/PrefectureSelector/index.tsx
@@ -25,11 +25,11 @@ export const PrefectureSelector: FC<PrefectureSelectorProps> = ({
 
   return (
     <section className="bg-white text-gray-700 rounded-lg shadow-md p-4">
-      <h2 className="text-lg font-bold">都道府県選択</h2>
-      <div className="mt-2">
+      <div className="grid grid-cols-[1fr_auto]">
+        <h2 className="text-lg font-bold">都道府県選択</h2>
         <Button variant="secondary" onClick={clearAll}>
           <XCircle />
-          すべてクリア
+          選択をクリア
         </Button>
       </div>
 

--- a/src/features/population-by-prefecture/components/PrefectureSelector/index.tsx
+++ b/src/features/population-by-prefecture/components/PrefectureSelector/index.tsx
@@ -25,7 +25,7 @@ export const PrefectureSelector: FC<PrefectureSelectorProps> = ({
 
   return (
     <section className="bg-white text-gray-700 rounded-lg shadow-md p-4">
-      <div className="grid grid-cols-[1fr_auto]">
+      <div className="grid grid-cols-[1fr_auto] items-center">
         <h2 className="text-lg font-bold">都道府県選択</h2>
         <Button variant="secondary" onClick={clearAll}>
           <XCircle />


### PR DESCRIPTION
# 概要
UIの微修正を行なっております。

- ページのtitleや見出しを修正
- 都道府県選択エリアのレイアウトやサイズなど調整
  - 全体的に余白が大きく画面が間延びしているように思えたので修正
- グラフの横幅を調整
  - minWidthを大きくしています。SP幅にした時minWidthが狭まりすぎると、グラフもみづらくなってしまうためです。
    - 画面幅を超える場合は、ページ全体ではなくグラフのみをスクロールすることで見えるようになっているため、表示崩れ等はない修正になります

# 動作確認
## PC
![スクリーンショット 2025-02-13 22 55 05](https://github.com/user-attachments/assets/aafd2b98-cd44-4ba4-bb85-3a44688c7a9e)
![スクリーンショット 2025-02-13 22 55 12](https://github.com/user-attachments/assets/ffc67c48-5403-4f3e-bedc-9cb3a9d8a1c9)


## SP
![スクリーンショット 2025-02-13 22 55 30](https://github.com/user-attachments/assets/41a825db-f4a5-498a-833b-b4fcba67527a)
![スクリーンショット 2025-02-13 22 55 47](https://github.com/user-attachments/assets/ed8b7983-e3e1-4469-a0e9-7aebae5f3c64)

スクロールできる
![スクリーンショット 2025-02-13 22 55 37](https://github.com/user-attachments/assets/906261cd-6a36-4019-9cd7-b66964955035)
